### PR TITLE
Bug fix: builder and special fields

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -4,7 +4,7 @@ const glob = require('glob');
 const Template = require('./template');
 const Utils = require('./utils');
 
-let Section;
+let models;
 let lastTree;
 
 /**
@@ -12,12 +12,12 @@ let lastTree;
  */
 class Builder {
   /*
-   * @param {{Section, templatesDir: string}} options - Section model and template directory
+   * @param {{models, templatesDir: string}} options - models and template directory
    *
    * @todo Remove {options}, and use regular ol' passed in variables
    */
-  constructor(options = { Section: undefined, templatesDir: undefined }) {
-    ({ Section } = options);
+  constructor(options = { models: undefined, templatesDir: undefined }) {
+    ({ models } = options);
     this.dir = options.templatesDir;
   }
 
@@ -40,12 +40,12 @@ class Builder {
     // TODO: Use Promise.all
     /* eslint-disable no-restricted-syntax, no-await-in-loop */
     for (const [name, params] of Object.entries(tree)) {
-      const section = await Section.rebuild(name, params);
+      const section = await models.Section.rebuild(name, params);
       existing.push(section.id);
     }
     /* eslint-enable no-restricted-syntax, no-await-in-loop */
 
-    await Section.destroyExceptExisting(existing);
+    await models.Section.destroyExceptExisting(existing);
     lastTree = tree;
   }
 
@@ -55,8 +55,9 @@ class Builder {
    * @todo Cache so this isn't as taxing on the load time
    */
   get isDirty() {
-    // TODO: Should remove _permalink and other special fields
-    return !Utils.isEqual(this.tree, lastTree);
+    const cleanedTree = _cleanTree(this.tree);
+    const cleanedLastTree = _cleanTree(lastTree);
+    return !Utils.isEqual(cleanedTree, cleanedLastTree);
   }
 
   /**
@@ -106,10 +107,34 @@ function _createTemplateTree(templates) {
 /* eslint-enable no-restricted-syntax */
 
 /**
+ * @private
+ *
+ * Removes special fields from the tree
+ *
+ * @param {Object} tree
+ * @return {Object} cleaned tree
+ */
+/* eslint-disable no-param-reassign */
+function _cleanTree(tree) {
+  const specialFields = Utils.keys(models.Record.SPECIAL_FIELDS);
+
+  return Utils.reduce(tree, (memo, params, name) => {
+    params.fields = Utils.omit(params.fields, specialFields);
+    memo[name] = params;
+    return memo;
+  }, {});
+}
+/* eslint-enable no-param-reassign */
+
+/**
+ * @private
+ *
  * Initializes the lastTree from Section entries
+ *
+ * @return {Object}
  */
 async function _initLastTree() {
-  const sections = await Section.findAll();
+  const sections = await models.Section.findAll();
 
   lastTree = Utils.reduce(sections, (memo, section) => {
     /* eslint-disable-next-line no-param-reassign */

--- a/lib/vapid.js
+++ b/lib/vapid.js
@@ -60,7 +60,7 @@ class Vapid {
     this.config = Utils.merge({}, defaults, options);
     this.paths = _paths(cwd, this.config.dataPath);
     this.db = _db(this.config.database, this.paths.data);
-    this.builder = new Builder({ Section: this.db.models.Section, templatesDir: this.paths.www });
+    this.builder = new Builder({ models: this.db.models, templatesDir: this.paths.www });
     this.watcher = env === 'development' && new Watcher(this.paths.www);
     this.liveReload = this.watcher && this.config.liveReload;
     this.buildOnStart = env === 'production';


### PR DESCRIPTION
The builder would always think the inital tree was dirty if
special fields (e.g. _permalink) were present in the templates.