### PR TITLE
Fix reordering records in a sortable section

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -348,9 +348,9 @@ router.get('records#new', '/sections/:id/records/new', findSection, async (ctx) 
 router.post('records#reorder', '/sections/:id/records/reorder', findSection, async (ctx) => {
   const { id, from, to } = ctx.request.body;
   const record = await Record.findById(id, { include: ['section'] });
-  const reorderer = new services.RecordOrderUpdater(record, from, to);
 
-  await reorderer.perform();
+  await services.RecordOrderUpdater.moveFromTo(record, from, to);
+
   ctx.status = 200;
 });
 
@@ -360,10 +360,18 @@ router.post('records#create', '/sections/:id/records', findSection, async (ctx) 
   let redirectTo;
 
   try {
+    record = await Record.build({ content: _content(ctx), section_id: section.id });
+
     // TODO: Can't figure out how to get section to load for validation,
     // so I'm using the record.section = section hack
-    record = await Record.build({ content: _content(ctx), section_id: section.id });
     record.section = section;
+
+    // Correctly position new records in sortable sections
+    if (section.sortable) {
+      const recordCnt = await Record.count();
+      record.position = recordCnt;
+    }
+
     await record.save();
 
     redirectTo = (() => {
@@ -424,6 +432,12 @@ router.get('records#delete', '/records/:id/delete', findRecord, async (ctx) => {
 
 router.post('/records/:id/delete', findRecord, async (ctx) => {
   await ctx.state.record.destroy();
+
+  // Reorder records after deleting from a sortable section
+  if (ctx.state.section.sortable) {
+    await services.RecordOrderUpdater.fixOrdering(ctx.state.section);
+  }
+
   ctx.flash('success', `Deleted ${ctx.state.section.labelSingular}`);
   ctx.redirect(router.url('records#index', ctx.state.section.id));
 });

--- a/lib/models/record.js
+++ b/lib/models/record.js
@@ -9,7 +9,7 @@ const SPECIAL_FIELDS = {
 };
 
 const DEFAULT_ORDER = [
-  ['position', 'ASC'],
+  ['position', 'DESC'],
   ['created_at', 'DESC'],
 ];
 

--- a/lib/services/record_order_updater.js
+++ b/lib/services/record_order_updater.js
@@ -1,45 +1,56 @@
 class RecordOrderUpdater {
-  constructor(record, from, to) {
-    this.record = record;
-    this.from = parseInt(from, 10);
-    this.to = parseInt(to, 10);
+  static async moveFromTo(record, from, to) {
+    const section = await RecordOrderUpdater._getSection(record);
+    const sectionRecords = await RecordOrderUpdater._getSectionRecords(section);
+    await RecordOrderUpdater._reorder(sectionRecords, parseInt(from, 10), parseInt(to, 10));
   }
 
-  async perform() {
-    this.section = await this._getSection();
-    this.siblings = await this._getSiblings();
-    await this._reorder();
+  static async fixOrdering(section) {
+    const sectionRecords = await RecordOrderUpdater._getSectionRecords(section);
+    await RecordOrderUpdater._updatePositions(sectionRecords, sectionRecords.length - 1);
   }
 
-  async _getSection() {
-    return this.record.section || this.record.getSection();
+  static async _getSection(record) {
+    return record.section || record.getSection();
   }
 
-  async _getSiblings() {
-    return this.section.getRecords({ order: [['position', 'ASC']] });
+  static async _getSectionRecords(section) {
+    return section.getRecords({ order: [['position', 'DESC']] });
   }
 
-  async _reorder() {
-    const startPos = this.to === 0 ? 0 : this.siblings[this.to].position + 1;
-    let sliceStart;
-    let sliceEnd;
+  static async _reorder(sectionRecords, from, to) {
+    let positionStart;
+    let recordsToUpdate;
 
-    if (this.from > this.to) {
-      sliceStart = this.to;
-      sliceEnd = this.from;
+    // Moving a record up in the section
+    if (from > to) {
+      positionStart = sectionRecords[to].position;
+      recordsToUpdate = sectionRecords.slice(to, from + 1);
+
+      // Move the last to the first
+      const record = recordsToUpdate.pop();
+      recordsToUpdate.unshift(record);
+
+    // Moving a record down in the section
     } else {
-      sliceStart = this.to + 1;
-      sliceEnd = this.siblings.length;
+      positionStart = sectionRecords[from].position;
+      recordsToUpdate = sectionRecords.slice(from, to + 1);
+
+      // Move the first to the last
+      const record = recordsToUpdate.shift();
+      recordsToUpdate.push(record);
     }
 
-    const items = this.siblings.slice(sliceStart, sliceEnd);
+    await RecordOrderUpdater._updatePositions(recordsToUpdate, positionStart);
+  }
+
+  static async _updatePositions(recordsToUpdate, positionStart) {
+    let position = positionStart;
     const promises = [];
-
-    items.unshift(this.record);
-
-    items.forEach((item, index) => {
-      const promise = item.update({ position: startPos + index });
+    recordsToUpdate.forEach((item) => {
+      const promise = item.update({ position });
       promises.push(promise);
+      position -= 1;
     });
 
     await Promise.all(promises);


### PR DESCRIPTION
So I know you assigned it already but I was bored so thought I'd take a crack at the proposed fix. :p

I went with reverse ordering the records in a sortable section (to make adding new records fast) and tried to make the reordering logic a little easier to reason about: basically slice out the relevant section, move the record in the order, then fix the positions based on descending value.

I also noticed when I got in there that the same bug for creating a record also exists for deleting a record so I fixed that too (I think). Definitely needs some 👀 

Fixes: #38 