### PR TITLE
Fix section url so reordering works

### DIFF
--- a/assets/dashboard/javascripts/dashboard/sortable.js
+++ b/assets/dashboard/javascripts/dashboard/sortable.js
@@ -15,6 +15,7 @@ document.addEventListener("turbolinks:load", () => {
       const id = item.getAttribute('data-id');
 
       $.post('./records/reorder', { id, from, to }).fail((err) => {
+        // TODO: probably need some better client-side error handling here
         alert('Error: could not reorder records');
       });
     });

--- a/views/layouts/default.ejs
+++ b/views/layouts/default.ejs
@@ -39,7 +39,7 @@
             <div class="header">Content</div>
             <div class="menu">
               <% contentSections.forEach(s => { %>
-                <a href="/dashboard/sections/<%- s.id %>" class="<% if (typeof section !== 'undefined' && s.id == section.id) { %>active <% } %>item">
+                <a href="/dashboard/sections/<%- s.id %>/" class="<% if (typeof section !== 'undefined' && s.id == section.id) { %>active <% } %>item">
                   <%- include(`../../assets/dashboard/images/${s.multiple ? 'multiple' : 'single'}.svg`) %>
                   <%- s.label %>
                 </a>


### PR DESCRIPTION
This is the minimal fix, however, navigation links in the ejs views and probably even the route to reorder in

https://github.com/vapid/vapid/blob/1e615ec35c7ea3c6b311327fe97105ce4de67545/assets/dashboard/javascripts/dashboard/sortable.js#L17 

should come from the router itself so routes and navigation have a single source of truth.

Fixes #24 