### PR TITLE
Checks to see if port is in use before starting server

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,6 +4,7 @@ const inquirer = require('inquirer');
 const updateNotifier = require('update-notifier');
 
 const pkg = require('../package.json');
+const services = require('../lib/services');
 const Deployer = require('../lib/deployer');
 const Generator = require('../lib/generator');
 const Logger = require('../lib/logger');
@@ -53,6 +54,12 @@ program
   .command('start')
   .description('start the server')
   .action(withVapid(async (vapid) => {
+    const portInUse = new services.PortChecker(vapid.config.port).perform();
+
+    if (portInUse) {
+      throw new Error(`Could not start server, port ${vapid.config.port} is alreadly in use.`);
+    }
+
     Logger.info(`Starting the ${vapid.env} server...`);
     await vapid.start();
     Logger.extra([

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -54,7 +54,7 @@ program
   .command('start')
   .description('start the server')
   .action(withVapid(async (vapid) => {
-    const portInUse = new services.PortChecker(vapid.config.port).perform();
+    const portInUse = await new services.PortChecker(vapid.config.port).perform();
 
     if (portInUse) {
       throw new Error(`Could not start server, port ${vapid.config.port} is alreadly in use.`);

--- a/lib/services/port_checker.js
+++ b/lib/services/port_checker.js
@@ -11,21 +11,21 @@ class PortChecker {
     const results = await Promise.all([
       this.listen(null),
       this.listen('0.0.0.0'),
-      this.listen('localhost')
+      this.listen('localhost'),
     ]);
 
     return Utils.some(results, r => r === true);
   }
 
-  async listen(hostname, callback) {
+  async listen(hostname) {
     const server = new net.Server();
     return new Promise((resolve) => {
-      server.on('error', (err) => {
+      server.on('error', () => {
         server.close();
         resolve(true);
       });
 
-      server.listen(this.port, hostname, (err) => {
+      server.listen(this.port, hostname, () => {
         server.close();
         resolve(false);
       });

--- a/lib/services/port_checker.js
+++ b/lib/services/port_checker.js
@@ -1,0 +1,36 @@
+const net = require('net');
+const Utils = require('../utils');
+
+// Based on https://github.com/node-modules/detect-port
+class PortChecker {
+  constructor(port) {
+    this.port = port;
+  }
+
+  async perform() {
+    const results = await Promise.all([
+      this.listen(null),
+      this.listen('0.0.0.0'),
+      this.listen('localhost')
+    ]);
+
+    return Utils.some(results, r => r === true);
+  }
+
+  async listen(hostname, callback) {
+    const server = new net.Server();
+    return new Promise((resolve) => {
+      server.on('error', (err) => {
+        server.close();
+        resolve(true);
+      });
+
+      server.listen(this.port, hostname, (err) => {
+        server.close();
+        resolve(false);
+      });
+    });
+  }
+}
+
+module.exports = PortChecker;

--- a/lib/vapid.js
+++ b/lib/vapid.js
@@ -136,8 +136,6 @@ class Vapid {
       this.builder.build();
     }
 
-    // console.log(builder.lastTree);
-
     // If watcher is present, attach its WebSocket server
     // and register the callback
     if (this.watcher) {

--- a/test/services/port_checker.test.js
+++ b/test/services/port_checker.test.js
@@ -1,0 +1,21 @@
+const net = require('net');
+const PortChecker = require('../../lib/services/port_checker');
+
+describe('#perform', () => {
+  test('sees if port is already in use', async () => {
+    let taken;
+    const port = 5150;
+    const server = new net.Server();
+
+    // No server running
+    taken = await new PortChecker(port).perform();
+    expect(taken).toBeFalsy();
+
+    // Server running
+    server.listen(port, async () => {
+      taken = await new PortChecker(port).perform();
+      expect(taken).toBeTruthy();
+      server.close();
+    });
+  });
+});


### PR DESCRIPTION
## Status
Ready

## Migrations
No

## Description
Adds a PortChecker service that checks to see if a port is in use before starting the Vapid server.

## Related Bugs
Fixes #5

## Steps to Reproduce

1. Start a vapid server in one terminal window.
2. Open a second terminal window, and launch another server (`bin/cli.js start .` to use the local/PR copy)
3. You should see an error message saying that the "port is already in use".
4. Application will safely exit.