### PR TITLE
Template option for parsing conditionals

### DIFF
--- a/lib/template/index.js
+++ b/lib/template/index.js
@@ -12,6 +12,9 @@ const BRANCH_REGEX = /^(?:(section|form)\s)?(\w+)(.*)/i;
 const LEAF_REGEX = /^(\w+)(.*)/i;
 const PARTIALS_REGEX = /{{\s*>\s*(\w+)\s*}}/g;
 const PARTIALS_DEPTH = 2;
+const DEFAULT_OPTIONS = {
+  parseConditionals: false,
+};
 
 /**
  * Template class
@@ -22,10 +25,11 @@ class Template {
    * @param {string} html
    * @param {array} partials - collection of partial templates
    */
-  constructor(html, partials = {}) {
+  constructor(html, partials = {}, options = {}) {
     // Worried about this getting too big, so it's being cleared.
     Goatee.clearCache();
     this.html = _replacePartials(html, partials);
+    this.options = Utils.merge({}, DEFAULT_OPTIONS, options);
   }
 
   /**
@@ -37,7 +41,7 @@ class Template {
    * @param {array} partials - collection of partial templates
    * @return {Template} - a new instance of Template
    */
-  static fromFile(filePath, partialPaths = []) {
+  static fromFile(filePath, partialPaths = [], options = {}) {
     const html = readFileSync(filePath, 'utf8');
     const partials = Utils.reduce(partialPaths, (memo, path) => {
       const key = basename(path, '.html').slice(1);
@@ -46,7 +50,7 @@ class Template {
       return memo;
     }, {});
 
-    return new Template(html, partials);
+    return new Template(html, partials, options);
   }
 
   /**
@@ -65,7 +69,7 @@ class Template {
       });
     }
 
-    return _walk({}, tokens);
+    return _walk.call(this, {}, tokens);
   }
 
   /**
@@ -103,16 +107,21 @@ function _walk(tree, branch, branchToken = 'general') {
   branch.forEach((leaf) => {
     switch (leaf[0]) {
       case 'name': {
-        const leafToken = leaf[1];
-        /* eslint-disable-next-line max-len */
-        const leafValue = Utils.merge(tree[branchToken].fields[leafToken] || {}, _parseLeafToken(leaf[1]));
-        tree[branchToken].fields[leafToken] = leafValue;
+        _addToTree(tree, branchToken, leaf[1]);
         break;
       }
       case '#': {
-        const [, keyword] = leaf[1].toLowerCase().match(LEAF_REGEX);
-        const token = Utils.includes(Goatee.CONDITIONALS, keyword) ? branchToken : leaf[1];
-        _walk(tree, leaf[4], token);
+        const [, keyword, remainder] = leaf[1].toLowerCase().match(LEAF_REGEX);
+
+        if (Utils.includes(Goatee.CONDITIONALS, keyword)) {
+          if (this.options.parseConditionals) {
+            _addToTree(tree, branchToken, Utils.trim(remainder));
+          }
+          _walk.call(this, tree, leaf[4], branchToken);
+        } else {
+          _walk.call(this, tree, leaf[4], leaf[1]);
+        }
+
         break;
       }
       default: {
@@ -159,6 +168,25 @@ function _parseLeafToken(token) {
     name: name.toLowerCase(),
     params: _parseParams(remainder),
   };
+}
+
+/**
+ * @private
+ *
+ * Parses a leaf token, and merges into the branch
+ *
+ * @params {Object} tree
+ * @params {string} branchToken
+ * @params {string} leftToken;
+ * @return {Object}
+ */
+function _addToTree(tree, branchToken, leafToken) {
+  /* eslint-disable max-len, no-param-reassign */
+  const leafValue = Utils.merge(tree[branchToken].fields[leafToken] || {}, _parseLeafToken(leafToken));
+  tree[branchToken].fields[leafToken] = leafValue;
+  /* eslint-enable max-len, no-param-reassign */
+
+  return tree;
 }
 
 /**

--- a/lib/vapid.js
+++ b/lib/vapid.js
@@ -229,7 +229,7 @@ async function _renderContent(uriPath) {
   }
 
   const partials = glob.sync(resolve(this.paths.www, '_*.html'));
-  const template = Template.fromFile(file, partials);
+  const template = Template.fromFile(file, partials, { parseConditionals: true });
   const tree = template.parse();
 
   /* eslint-disable no-restricted-syntax */

--- a/test/__snapshots__/template.test.js.snap
+++ b/test/__snapshots__/template.test.js.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`#parse parses conditionals 1`] = `
+Object {
+  "general": Object {
+    "fields": Object {},
+    "keyword": undefined,
+    "name": "general",
+    "params": Object {},
+  },
+}
+`;
+
+exports[`#parse parses conditionals 2`] = `
+Object {
+  "general": Object {
+    "fields": Object {
+      "foo": Object {
+        "name": "foo",
+        "params": Object {},
+      },
+    },
+    "keyword": undefined,
+    "name": "general",
+    "params": Object {},
+  },
+}
+`;
+
 exports[`#parse parses order by clause 1`] = `
 Object {
   "general": Object {

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -92,6 +92,13 @@ describe('#parse', () => {
     const orderBy = new Template('{{#section offices order=city,-name}}{{/section}}').parse();
     expect(orderBy).toMatchSnapshot();
   });
+
+  test('parses conditionals', () => {
+    const conditional = '{{#if foo}}Foo{{/if}}';
+
+    expect(new Template(conditional).parse()).toMatchSnapshot();
+    expect(new Template(conditional, {}, { parseConditionals: true }).parse()).toMatchSnapshot();
+  });
 });
 
 /**


### PR DESCRIPTION
Fixes #50.

* Adds an option to `Template` for parsing conditionals (e.g. `{{#if foo}}Foo{{/if}}`) as if they were template tags (e.g. `{{foo}}`). See #50 for why this is necessary.
* Main `_renderContent_ method now uses this option, so that conditionals can be used on page requests.