### PR TITLE
New permalink format

### DIFF
--- a/lib/models/record.js
+++ b/lib/models/record.js
@@ -79,15 +79,11 @@ module.exports = (sequelize, DataTypes) => {
        */
       permalink() {
         const section = this.get('section');
-        const slug = Utils.kebabCase(this.content.title || this.content.name);
+        const name = Utils.kebabCase(this.content.title || this.content.name);
+        const slug = name ? `${name}-${this.id}` : this.id;
 
         if (section.multiple) {
-          const path = Utils.compact([
-            section.name,
-            this.id,
-            slug,
-          ]).join('/');
-          return `/${path}`;
+          return `/${section.name}/${slug}`;
         }
 
         return null;

--- a/lib/services/uri_path_analyzer.js
+++ b/lib/services/uri_path_analyzer.js
@@ -21,8 +21,10 @@ class UriPathAnalyzer {
   perform() {
     const sysPath = join(this.templateDir, this.path);
     let file;
+    let recordSlug;
     let recordId;
     let sectionName;
+    let partial;
 
     if (fs.existsSync(sysPath)) {
       const stats = fs.statSync(sysPath);
@@ -39,8 +41,9 @@ class UriPathAnalyzer {
       if (fs.existsSync(htmlPath)) {
         file = htmlPath;
       } else {
-        [sectionName, recordId] = this.path.slice(1).split('/');
-        const partial = resolve(this.templateDir, `_${sectionName}.html`);
+        [sectionName, recordSlug] = this.path.slice(1).split('/');
+        recordId = recordSlug.split('-').pop();
+        partial = resolve(this.templateDir, `_${sectionName}.html`);
 
         if (fs.existsSync(partial) && !Utils.isNaN(recordId)) {
           file = partial;

--- a/test/services/uri_path_analyzer.test.js
+++ b/test/services/uri_path_analyzer.test.js
@@ -30,8 +30,18 @@ describe('#perform', () => {
   });
 
   test('extracts sectionName and recordId', () => {
-    const analyzer = new UriPathAnalyzer('/offices/123/testing', templateDir);
-    const results = analyzer.perform();
+    // Old format
+    let results = new UriPathAnalyzer('/offices/123/testing', templateDir).perform();
+    expect(results[1]).toEqual('offices');
+    expect(results[2]).toEqual('123');
+
+    // New format
+    results = new UriPathAnalyzer('/offices/testing-123', templateDir).perform();
+    expect(results[1]).toEqual('offices');
+    expect(results[2]).toEqual('123');
+
+    // Titleless
+    results = new UriPathAnalyzer('/offices/123', templateDir).perform();
     expect(results[1]).toEqual('offices');
     expect(results[2]).toEqual('123');
   });


### PR DESCRIPTION
Moving record ID to the end of the slug, for better readability and SEO.

**Old format**
/posts/123/hello-world

**New format**
/posts/hello-world-123

_Note: this is a non-breaking change, the old format still routes correctly._