### PR TITLE
Form tag now accepts `action` parameter

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -335,7 +335,7 @@ router.get('records#new', '/sections/:id/records/new', findSection, async (ctx) 
     await ctx.render('records/new', title, {
       form: 'email',
       fields,
-      recipient,
+      action: section.options.action || `https://formspree.io/${recipient}`,
       subject: section.options.subject,
       next: section.options.next,
       Form,

--- a/lib/models/section.js
+++ b/lib/models/section.js
@@ -247,17 +247,17 @@ module.exports = (sequelize, DataTypes) => {
 
       if (!recipient) {
         const user = await this.sequelize.models.User.findOne();
-        recipient = user ? user.email : null;
+        recipient = user ? user.email : '';
       }
 
       // TODO: This should iterate over args.fields, not section.fields,
       //       so livereload works
       return ejs.render(formTemplate, {
         section: this,
+        action: options.action || `https://formspree.io/${recipient}`,
         subject: options.subject,
         next: options.next,
         fields,
-        recipient,
         Form,
       });
     }

--- a/views/records/_form_email.ejs
+++ b/views/records/_form_email.ejs
@@ -1,4 +1,4 @@
-<form class="form" action="https://formspree.io/<%- recipient %>" method="post">
+<form class="form" action="<%- action %>" method="post">
   <% for (let fieldName in fields) { %>
     <%- Form.field(fieldName, fieldName, fields[fieldName]) %>
   <% } %>


### PR DESCRIPTION
Resolves #31.

This new option would allow someone to override the Formspree action so they could host the form processor themselves.

```
{{#form action="http://example.com"}}
  {{name}}
{{/form}}
```