### PR TITLE
Fix WebSocket error when not localhost:3000

### DIFF
--- a/assets/dashboard/javascripts/dashboard/websocket.js
+++ b/assets/dashboard/javascripts/dashboard/websocket.js
@@ -1,5 +1,7 @@
-if ('WebSocket' in window) {
-  const ws = new WebSocket('ws://localhost:3000/livereload');
+const liveReload = document.querySelector('meta[name=livereload]');
+
+if ('WebSocket' in window && liveReload) {
+  const ws = new WebSocket(`ws://${location.host}/livereload`);
 
   document.addEventListener("turbolinks:load", () => {
     const $build = $('.build.button');

--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -28,6 +28,7 @@ let User;
 let builder;
 let uploadsDir;
 let siteName;
+let liveReload;
 
 /**
  * Dashboard
@@ -48,6 +49,7 @@ class Dashboard {
       builder,
       uploadsDir,
       siteName,
+      liveReload,
     } = sharedVars);
   }
 
@@ -133,6 +135,7 @@ router.use(async (ctx, next) => {
       flash: ctx.flash(),
       requestURL: ctx.request.url,
       siteName,
+      liveReload,
     });
 
     await render(`layouts/${layout}`, locals);

--- a/lib/vapid.js
+++ b/lib/vapid.js
@@ -77,6 +77,7 @@ class Vapid {
       builder: this.builder,
       uploadsDir: this.paths.uploads,
       siteName: Utils.startCase(siteName),
+      liveReload: this.liveReload,
     });
 
     // Set secret key

--- a/views/layouts/default.ejs
+++ b/views/layouts/default.ejs
@@ -7,6 +7,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="csrf-token" content="<%- csrf %>">
+  <% if (liveReload) { -%><meta name="livereload" content="<%- liveReload %>"><% } -%>
 
   <link rel="stylesheet" href="/dashboard/stylesheets/dashboard.css" data-turbolinks-track="reload">
   <script src="/dashboard/javascripts/dashboard.js" data-turbolinks-track="reload"></script>


### PR DESCRIPTION
Fixes #75.

* WebSocket connection uses `location.host` to determine host/port.
* Only attempts connection if `liveReload` config is true.