### PR TITLE
Moved example site's background image to header

### DIFF
--- a/site_template/www/index.html
+++ b/site_template/www/index.html
@@ -7,8 +7,8 @@
   <link href="https://fonts.googleapis.com/css?family=Monoton|Work+Sans:400,800" rel="stylesheet">
   <link rel="stylesheet" type="text/css" href="/stylesheets/site.css">
 </head>
-<body style="background-image: url({{background_image type=image tag=false required=false}})">
-  <header class="header">
+<body>
+  <header class="header" style="background-image: url({{background_image type=image tag=false required=false}})">
     <h2>A New Site</h2>
     <h1><span>Hello, {{vapid label="Greeting"}}</span></h1>
 


### PR DESCRIPTION
Having it on the body was a mistake. It should be on the header, so it's immediately visible once you upload an image.