### PR TITLE
Fix: Webpack modules

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -265,23 +265,23 @@ async function _content(Section) {
  */
 async function _compileAssets(wwwDir, tmpDir) {
   const nodeDir = resolve(wwwDir, '../node_modules');
-  const moduleDirs = (function () {
+  const moduleDirs = (function _moduleDirs() {
     const dirs = [wwwDir];
     if (fs.existsSync(nodeDir)) dirs.push(nodeDir);
     return dirs;
-  })();
+  }());
 
   const config = webPackConfig('production', tmpDir, moduleDirs, tmpDir);
   if (Utils.isEmpty(config.entry)) return;
 
   const compiler = Webpack(config);
-  await new Promise((resolve, reject) => {
+  await new Promise((_resolve, _reject) => {
     compiler.run((err, stats) => {
       if (stats.hasErrors()) {
-        reject(new Error('Failed to compile assets'));
+        _reject(new Error('Failed to compile assets'));
       }
 
-      resolve();
+      _resolve();
     });
   });
 }

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -264,14 +264,24 @@ async function _content(Section) {
  * Compiles Webpack assets
  */
 async function _compileAssets(wwwDir, tmpDir) {
-  const config = webPackConfig('production', tmpDir, wwwDir, tmpDir);
+  const nodeDir = resolve(wwwDir, '../node_modules');
+  const moduleDirs = (function () {
+    const dirs = [wwwDir];
+    if (fs.existsSync(nodeDir)) dirs.push(nodeDir);
+    return dirs;
+  })();
+
+  const config = webPackConfig('production', tmpDir, moduleDirs, tmpDir);
   if (Utils.isEmpty(config.entry)) return;
 
   const compiler = Webpack(config);
-  await new Promise((_resolve, _reject) => {
-    compiler.run((err) => {
-      if (err) { _reject(err); }
-      _resolve();
+  await new Promise((resolve, reject) => {
+    compiler.run((err, stats) => {
+      if (stats.hasErrors()) {
+        reject(new Error('Failed to compile assets'));
+      }
+
+      resolve();
     });
   });
 }


### PR DESCRIPTION
* Webpack module now get `node_modules` in its path on deploy
* Better error handling for Webpack failures