### PR TITLE
Allow partials in subfolders

### DIFF
--- a/lib/template/index.js
+++ b/lib/template/index.js
@@ -1,6 +1,6 @@
 // TODO: Clean this up. Lots of hacky stuff in here
 const { readFileSync } = require('fs');
-const { basename } = require('path');
+const { parse, relative } = require('path');
 const Boom = require('boom');
 const Goatee = require('./goatee');
 const Utils = require('../utils');
@@ -10,7 +10,7 @@ const QUOTES = ['"', "'"];
 // TODO: Don't need branch *and* leaf
 const BRANCH_REGEX = /^(?:(section|form)\s)?(\w+)(.*)/i;
 const LEAF_REGEX = /^(\w+)(.*)/i;
-const PARTIALS_REGEX = /{{\s*>\s*(\w+)\s*}}/g;
+const PARTIALS_REGEX = /{{\s*>\s*([\w/_-]+)\s*}}/g;
 const PARTIALS_DEPTH = 2;
 const DEFAULT_OPTIONS = {
   parseConditionals: false,
@@ -38,13 +38,20 @@ class Template {
    * Reads HTML from a file, then creates a Template instance
    *
    * @param {string} filePath - the absolute path to a file
+   * @param {string} basePath - shared base path of file and partials
    * @param {array} partials - collection of partial templates
+   * @param {object} options
    * @return {Template} - a new instance of Template
    */
-  static fromFile(filePath, partialPaths = [], options = {}) {
+  static fromFile(filePath, basePath = process.cwd(), partialPaths = [], options = {}) {
     const html = readFileSync(filePath, 'utf8');
     const partials = Utils.reduce(partialPaths, (memo, path) => {
-      const key = basename(path, '.html').slice(1);
+      const rel = relative(basePath, path);
+      const parts = parse(rel);
+      const key = Utils.chain([parts.dir, parts.name.slice(1)])
+        .compact()
+        .join('/')
+        .value();
       /* eslint-disable-next-line no-param-reassign */
       memo[key] = readFileSync(path, 'utf-8');
       return memo;

--- a/lib/vapid.js
+++ b/lib/vapid.js
@@ -265,8 +265,8 @@ async function _renderContent(uriPath) {
     throw Boom.notFound('Template not found');
   }
 
-  const partials = glob.sync(resolve(this.paths.www, '_*.html'));
-  const template = Template.fromFile(file, partials, { parseConditionals: true });
+  const partials = glob.sync(resolve(this.paths.www, '**/_*.html'));
+  const template = Template.fromFile(file, this.paths.www, partials, { parseConditionals: true });
   const tree = template.parse();
 
   /* eslint-disable no-restricted-syntax */

--- a/test/__snapshots__/template.test.js.snap
+++ b/test/__snapshots__/template.test.js.snap
@@ -125,6 +125,7 @@ exports[`.fromFile reads partials from disk 1`] = `
   Hello, .
 
   I'm a partial. 
+  I'm a subdirectory partial. 
 </body>
 </html>"
 `;

--- a/test/fixtures/subdirectory/_partial.html
+++ b/test/fixtures/subdirectory/_partial.html
@@ -1,0 +1,1 @@
+I'm a subdirectory partial. {{name}}

--- a/test/fixtures/with_partials.html
+++ b/test/fixtures/with_partials.html
@@ -7,5 +7,6 @@
   Hello, {{name}}.
 
   {{> partial}}
+  {{> subdirectory/partial}}
 </body>
 </html>

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -38,9 +38,13 @@ describe('.fromFile', () => {
   });
 
   test('reads partials from disk', () => {
-    const filePath = resolve(__dirname, 'fixtures/with_partial.html');
-    const partials = [resolve(__dirname, 'fixtures', '_partial.html')];
-    const template = Template.fromFile(filePath, partials);
+    const basePath = resolve(__dirname, 'fixtures');
+    const filePath = resolve(basePath, 'with_partials.html');
+    const partials = [
+      resolve(basePath, '_partial.html'),
+      resolve(basePath, 'subdirectory/_partial.html'),
+    ];
+    const template = Template.fromFile(filePath, basePath, partials);
 
     expect(template.render()).toMatchSnapshot();
   });


### PR DESCRIPTION
Previously, only partials in the `www` directory were recognized. e.g.,

```
# To include _about.html
{{> about}}
```

Now, partials can be located in subfolders:

```
# To include some/subfolder/_about.html
{{> some/subfolder/about}}
```

Resolves #97 