### PR TITLE
Fixes bug where routes returned partial content

### DIFF
--- a/lib/services/uri_path_analyzer.js
+++ b/lib/services/uri_path_analyzer.js
@@ -20,7 +20,7 @@ class UriPathAnalyzer {
    */
   perform() {
     const sysPath = join(this.templateDir, this.path);
-    let file;
+    let file = null;
     let recordSlug;
     let recordId;
     let sectionName;
@@ -45,7 +45,7 @@ class UriPathAnalyzer {
         recordId = recordSlug.split('-').pop();
         partial = resolve(this.templateDir, `_${sectionName}.html`);
 
-        if (fs.existsSync(partial) && !Utils.isNaN(recordId)) {
+        if (fs.existsSync(partial) && recordSlug && !Utils.isNaN(recordId)) {
           file = partial;
         }
       }

--- a/test/services/uri_path_analyzer.test.js
+++ b/test/services/uri_path_analyzer.test.js
@@ -44,5 +44,9 @@ describe('#perform', () => {
     results = new UriPathAnalyzer('/offices/123', templateDir).perform();
     expect(results[1]).toEqual('offices');
     expect(results[2]).toEqual('123');
+
+    // Invalid
+    results = new UriPathAnalyzer('/offices', templateDir).perform();
+    expect(results[0]).toBeNull();
   });
 });


### PR DESCRIPTION
e.g., `/offices` would return the `_offices.html` body