### PR TITLE
Deploy ordered records

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -252,7 +252,9 @@ async function _updateSite(siteId, tree, manifest, content) {
  * @return {Object} content
  */
 async function _content(Section) {
-  const contentSections = await Section.scope('content').findAll({ include: 'records' });
+  const { Record } = Section.sequelize.models;
+  const order = Utils.map(Record.DEFAULT_ORDER, (o) => { o.unshift('records'); return o; });
+  const contentSections = await Section.scope('content').findAll({ include: 'records', order });
   return Utils.reduce(contentSections, (memo, section) => {
     /* eslint-disable-next-line no-param-reassign */
     memo[section.name] = Utils.map(section.records, record => record.get('content'));


### PR DESCRIPTION
Right now, when you deploy a site to the Vapid hosting service, sortable sections aren't imported in the correct order. This PR fixes that issue, so record order on production matches your local env.

Resolves #107 