### PR TITLE
Allow embedded images in WYSIWYG if `images=true`

### DIFF
--- a/assets/dashboard/javascripts/dashboard/wysiwyg.js
+++ b/assets/dashboard/javascripts/dashboard/wysiwyg.js
@@ -21,7 +21,7 @@ class Linebreak extends Break {
 Linebreak.blotName = 'linebreak';
 Linebreak.tagName = 'BR';
 
-Quill.register(Linebreak)
+Quill.register(Linebreak);
 
 const options = {
   modules: {
@@ -65,6 +65,9 @@ document.addEventListener("turbolinks:load", () => {
   const editors = document.querySelectorAll('.wysiwyg');
 
   [].forEach.call(editors, (editor) => {
+    options.modules.toolbar[4] = editor.getAttribute('data-images') === "true" ?
+      ['image'] : [];
+
     const quill = new Quill(editor, options);
     const input = editor.nextElementSibling;
 

--- a/lib/directives/html.js
+++ b/lib/directives/html.js
@@ -10,6 +10,7 @@ const Utils = require('../utils');
 const DEFAULTS = {
   options: {
     editor: 'wysiwyg',
+    images: false,
   },
 };
 
@@ -39,7 +40,7 @@ module.exports = (BaseDirective) => {
       switch (this.options.editor) {
         case 'wysiwyg':
           return `
-            <div class="wysiwyg">${value}</div>
+            <div class="wysiwyg" data-images="${this.options.images}">${value}</div>
             <input id="${name}" type="hidden" name="${name}" value="${Utils.escape(value)}">`;
         default:
           return `

--- a/test/directives/html.test.js
+++ b/test/directives/html.test.js
@@ -7,6 +7,10 @@ describe('.constructor', () => {
   test('sets editor=wysiwyg by default', () => {
     expect(vanilla.options.editor).toEqual('wysiwyg');
   });
+
+  test('sets images=false by default', () => {
+    expect(vanilla.options.images).toEqual(false);
+  });
 });
 
 describe('#input', () => {
@@ -17,6 +21,16 @@ describe('#input', () => {
   test('renders ACE editor if editor=false', () => {
     const directive = new HTMLDirective({ editor: false });
     expect(directive.input()).toMatch(/ace_editor/);
+  });
+
+  test('renders data-images attribute for WYSIWYG', () => {
+    expect(vanilla.input()).toMatch(/data-images="false"/);
+
+    let directive = new HTMLDirective({ images: true });
+    expect(directive.input()).toMatch(/data-images="true"/);
+
+    directive = new HTMLDirective({ editor: 'markdown', images: true });
+    expect(directive.input()).not.toMatch(/data-images/);
   });
 });
 


### PR DESCRIPTION
`{{body type=html images=true}}`

now adds an upload-image button to the WYSIWYG editor

![screen shot 2019-02-10 at 10 28 34 am](https://user-images.githubusercontent.com/44719/52536327-b296b200-2d1e-11e9-82b7-f3256600d128.png)

Resolves #96 