### PR TITLE
Accessibility:  removing `outline: none` 

### DIFF
--- a/assets/dashboard/stylesheets/_buttons.scss
+++ b/assets/dashboard/stylesheets/_buttons.scss
@@ -14,7 +14,6 @@
   cursor: pointer;
   background-color: $purple-light;
   background-image: linear-gradient(to bottom, $purple-light, $purple);
-  outline: none;
 
   &:hover {
     background: $purple;

--- a/assets/dashboard/stylesheets/_forms.scss
+++ b/assets/dashboard/stylesheets/_forms.scss
@@ -7,7 +7,6 @@
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
-    outline: none;
   }
 
   input:not(.button),

--- a/assets/dashboard/stylesheets/_wysiwyg.scss
+++ b/assets/dashboard/stylesheets/_wysiwyg.scss
@@ -29,7 +29,6 @@
   button,
   .ql-picker-item,
   .ql-picker-label {
-    outline: none;
 
     &:hover,
     &.ql-active {

--- a/assets/dashboard/stylesheets/semantic/_checkbox.scss
+++ b/assets/dashboard/stylesheets/semantic/_checkbox.scss
@@ -23,7 +23,6 @@
   display: inline-block;
   -webkit-backface-visibility: hidden;
           backface-visibility: hidden;
-  outline: none;
   vertical-align: baseline;
   font-style: normal;
   min-height: 17px;
@@ -40,7 +39,6 @@
   top: 0px;
   left: 0px;
   opacity: 0 !important;
-  outline: none;
   z-index: 3;
   width: 17px;
   height: 17px;
@@ -56,7 +54,6 @@
   position: relative;
   display: block;
   padding-left: 1.85714em;
-  outline: none;
   font-size: 1em;
   font-weight: normal;
 }

--- a/assets/dashboard/stylesheets/semantic/_dropdown.scss
+++ b/assets/dashboard/stylesheets/semantic/_dropdown.scss
@@ -17,7 +17,6 @@
   cursor: pointer;
   position: relative;
   display: inline-block;
-  outline: none;
   text-align: left;
   -webkit-transition: width 0.1s ease, -webkit-box-shadow 0.1s ease;
   transition: width 0.1s ease, -webkit-box-shadow 0.1s ease;
@@ -40,7 +39,6 @@
   cursor: auto;
   position: absolute;
   display: none;
-  outline: none;
   top: 100%;
   min-width: -webkit-max-content;
   min-width: -moz-max-content;
@@ -421,7 +419,6 @@ select.ui.dropdown {
   -webkit-overflow-scrolling: touch;
   border-top-width: 0px !important;
   width: auto;
-  outline: none;
   margin: 0px -1px;
   min-width: calc(100% +  2px );
   width: calc(100% +  2px );
@@ -571,7 +568,6 @@ select.ui.dropdown {
   top: 0em;
   left: 1px;
   width: 100%;
-  outline: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
   padding: inherit;
 }

--- a/assets/dashboard/vendor/quill.snow.scss
+++ b/assets/dashboard/vendor/quill.snow.scss
@@ -33,7 +33,6 @@
   box-sizing: border-box;
   line-height: 1.42;
   height: 100%;
-  outline: none;
   overflow-y: auto;
   padding: 12px 15px;
   tab-size: 4;
@@ -417,10 +416,7 @@
   float: left;
   height: 100%;
 }
-.ql-snow.ql-toolbar button:active:hover,
-.ql-snow .ql-toolbar button:active:hover {
-  outline: none;
-}
+
 .ql-snow.ql-toolbar input.ql-image[type=file],
 .ql-snow .ql-toolbar input.ql-image[type=file] {
   display: none;


### PR DESCRIPTION
Removing the `outline: none` param allows for users to see where they
are when navigating the dashboard via the keyboard.

https://www.w3.org/WAI/WCAG21/quickref/#focus-visible