### PR TITLE
Allow SVG and animated GIF uploads without Sharp modifications

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -1,10 +1,12 @@
 const bodyParser = require('koa-bodyparser');
 const multipartParser = require('koa-busboy');
-const { parse, resolve } = require('path');
+const { parse, resolve, extname } = require('path');
 const passport = require('koa-passport');
 const sharp = require('sharp');
 const url = require('url');
 const views = require('koa-views');
+const { readFileSync, writeFileSync } = require('fs');
+const animated = require('animated-gif-detector');
 const Boom = require('boom');
 const LocalStrategy = require('passport-local');
 const Router = require('koa-router');
@@ -561,11 +563,17 @@ async function _content(ctx) {
 async function _saveFile(file) {
   const fileName = _fileDigest(file);
   const savePath = resolve(uploadsDir, fileName);
+  const buffer = readFileSync(file.path);
 
-  // Ensures that EXIF rotated images are oriented correctly
-  await sharp(file.path)
-    .rotate()
-    .toFile(savePath);
+  // Sharp can't output SVG or animated GIF
+  if (animated(buffer) || extname(file.path) === '.svg') {
+    writeFileSync(savePath, buffer, { encoding: 'binary' });
+  } else {
+    // Ensures that EXIF rotated images are oriented correctly
+    await sharp(buffer)
+      .rotate()
+      .toFile(savePath);
+  }
 
   return fileName;
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     ]
   },
   "dependencies": {
+    "animated-gif-detector": "^1.2.0",
     "aws4": "^1.7.0",
     "bcrypt": "^3.0.3",
     "boom": "^7.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,6 +375,13 @@ alphanum-sort@^1.0.1, alphanum-sort@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
 
+animated-gif-detector@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/animated-gif-detector/-/animated-gif-detector-1.2.0.tgz#cb2f9911ca8024f2b34c693b7fd64542ee416189"
+  integrity sha1-yy+ZEcqAJPKzTGk7f9ZFQu5BYYk=
+  dependencies:
+    inherits "^2.0.1"
+
 ansi-align@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"


### PR DESCRIPTION
Previously, any uploaded image had its orientation corrected by Sharp, which caused problems for both SVGs and animated GIFs. This PR allows SVGs and animated GIFs to bypass Sharp.

Resolves #116 