### PR TITLE
Hide the General section nav if it's empty

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -220,13 +220,7 @@ router.get('auth#sign_out', '/sign_out', async (ctx) => {
 router.use(async (ctx, next) => {
   if (ctx.isAuthenticated()) {
     // For the nav menu
-    ctx.state.contentSections = await Section.scope('content').findAll({
-      order: [
-        [Sequelize.literal(`CASE WHEN name = '${Section.DEFAULT_NAME}' THEN 1 ELSE 0 END`), 'DESC'],
-        ['multiple', 'ASC'],
-        ['name', 'ASC'],
-      ],
-    });
+    ctx.state.contentSections = await _getContentSections();
     ctx.state.formSections = await Section.scope('forms').findAll({ order: [['name', 'ASC']] });
     ctx.state.showBuild = local;
     ctx.state.needsBuild = builder.isDirty;
@@ -445,7 +439,8 @@ router.post('/records/:id/delete', findRecord, async (ctx) => {
  */
 
 async function defaultSection(ctx, next) {
-  ctx.state.section = await Section.findGeneral();
+  const sections = await _getContentSections();
+  ctx.state.section = sections[0] || await Section.findGeneral();
   await next();
 }
 
@@ -477,6 +472,21 @@ async function findRecord(ctx, next) {
 /*
  * PRIVATE METHODS
  */
+
+async function _getContentSections() {
+  return Section.scope('content').findAll({
+    where: {
+      fields: {
+        [Sequelize.Op.ne]: {},
+      },
+    },
+    order: [
+      [Sequelize.literal(`CASE WHEN name = '${Section.DEFAULT_NAME}' THEN 1 ELSE 0 END`), 'DESC'],
+      ['multiple', 'ASC'],
+      ['name', 'ASC'],
+    ],
+  });
+}
 
 async function _newRecordAction(ctx, errors = {}) {
   const title = ctx.state.section.repeating ? `New ${ctx.state.section.labelSingular}` : ctx.state.section.label;


### PR DESCRIPTION
Right now, even if you have no fields in the General section, the section name and link appear in the Navbar. This PR hides the General section if it's empty, and redirects to the first available section (if possible).

## Before
![Screen Shot 2019-03-12 at 2 02 00 PM](https://user-images.githubusercontent.com/44719/54228194-a180c280-44cf-11e9-9c75-ed2145f7113a.png)

## After
![Screen Shot 2019-03-12 at 2 02 27 PM](https://user-images.githubusercontent.com/44719/54228199-a34a8600-44cf-11e9-85be-c3819b0968cf.png)
