### PR TITLE
Use wss:// for sites serving https://

### DIFF
--- a/assets/dashboard/javascripts/dashboard/websocket.js
+++ b/assets/dashboard/javascripts/dashboard/websocket.js
@@ -1,7 +1,7 @@
 const liveReload = document.querySelector('meta[name=livereload]');
 
 if ('WebSocket' in window && liveReload) {
-  const ws = new WebSocket(`ws://${location.host}/livereload`);
+  const ws = (window.location.protocol == 'https:')? new WebSocket(`wss://${location.host}/livereload`) : new WebSocket(`ws://${location.host}/livereload`) ;
 
   document.addEventListener("turbolinks:load", () => {
     const $build = $('.build.button');


### PR DESCRIPTION
- Check if if content is rendered over ssl
- Setup either ws:// or wss:// depening if the site is rendered over ssl