### PR TITLE
Reorder sections/fields via a new `priority` option

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -483,6 +483,7 @@ async function _getContentSections() {
     order: [
       [Sequelize.literal(`CASE WHEN name = '${Section.DEFAULT_NAME}' THEN 1 ELSE 0 END`), 'DESC'],
       ['multiple', 'ASC'],
+      [Sequelize.cast(Sequelize.json('options.priority'), 'integer'), 'ASC'],
       ['name', 'ASC'],
     ],
   });

--- a/lib/directives/base.js
+++ b/lib/directives/base.js
@@ -12,6 +12,7 @@ const DEFAULTS = {
   options: {
     label: undefined,
     help: undefined,
+    priority: undefined,
     default: '',
   },
 

--- a/lib/models/section.js
+++ b/lib/models/section.js
@@ -127,7 +127,7 @@ module.exports = (sequelize, DataTypes) => {
             ...value,
             _name: key,
           }], [])
-          .sortBy((f) => parseInt(f.priority))
+          .sortBy(f => parseInt(f.priority, 10))
           .value();
       },
     },

--- a/lib/models/section.js
+++ b/lib/models/section.js
@@ -12,6 +12,7 @@ const DEFAULTS = {
   name: 'general',
   limit: 1000,
   offset: 0,
+  priority: 9999999999,
 };
 
 const FORM_ALLOWED_TYPES = [
@@ -114,6 +115,21 @@ module.exports = (sequelize, DataTypes) => {
       hasFields: function hasFields() {
         return Object.keys(this.fields).length > 0;
       },
+
+      /**
+       * Sort fields by priority
+       *
+       * @return {array}
+       */
+      sortedFields: function sortedFields() {
+        return Utils.chain(this.fields)
+          .reduce((result, value, key) => [...result, {
+            ...value,
+            _name: key,
+          }], [])
+          .sortBy((f) => parseInt(f.priority))
+          .value();
+      },
     },
 
     /**
@@ -189,7 +205,7 @@ module.exports = (sequelize, DataTypes) => {
 
     return section.update({
       form: params.form,
-      options: params.options,
+      options: { priority: DEFAULTS.priority, ...params.options },
       multiple,
       sortable,
       fields,

--- a/views/records/_form_content.ejs
+++ b/views/records/_form_content.ejs
@@ -1,6 +1,6 @@
 <% if (section.hasFields) { %>
 <form class="form" action="<%- action %>" method="post" enctype="multipart/form-data" data-autosave="true" novalidate>
-  <% for (let fieldName in section.fields) { %>
+  <% for (const { _name: fieldName } of section.sortedFields) { %>
     <%- Form.field(`content[${fieldName}]`, fieldName, section.fields[fieldName], record.content[fieldName], errors.hasOwnProperty(fieldName) && errors[fieldName]) %>
   <% } %>
 

--- a/views/records/edit.ejs
+++ b/views/records/edit.ejs
@@ -6,7 +6,7 @@
 <section class="section">
   <div class="content">
     <form class="form" action="<%- action %>" method="post" enctype="multipart/form-data" data-autosave="true" novalidate>
-      <% for (let fieldName in record.section.fields) { %>
+      <% for (const { _name: fieldName } of record.section.sortedFields) { %>
         <%- Form.field(`content[${fieldName}]`, fieldName, section.fields[fieldName], record.content[fieldName], errors.hasOwnProperty(fieldName) && errors[fieldName]) %>
       <% } %>
 


### PR DESCRIPTION
Previously, Vapid would order sections alphabetically, and fields by their order of appearance in the HTML. Now, you can pass a `priority` option to them to specify their ordering in the dashboard.

```
#The input fields will appear as: title, body, photo
{{#section about}}
  {{photo type=image}}
  {{title priority=1}}
  {{body type=html priority=2}}
{{/section}}

# This section will appear before About
{{#section another priority=1}}
  {{title}}
{{/section}}

# The Bios and Offices sections will still appear after About/Another (see below)
{{#section bios multiple=true}}
  {{photo type=image}}
  {{name priority=1}}
{{/section}}

{{#section offices multiple=true priority=1}}
  {{name}}
  {{city}}
{{/section}}

```

A few things to note:

- The `General` section will always be first (unless it has no fields, in which case it will be hidden)
- Subsequent sections will still be grouped into non-repeating sections followed by repeating sections (see screenshot below)
- Sections/fields that don't specify a priority will appear at the end

<img width="1398" alt="Screen Shot 2019-04-11 at 12 19 32 PM" src="https://user-images.githubusercontent.com/44719/55977311-1de3fe00-5c54-11e9-9fb7-76b3bd63c4d5.png">
