### PR TITLE
Allow `multiple=true` to forcefully query for multiple records

### DIFF
--- a/lib/vapid.js
+++ b/lib/vapid.js
@@ -271,7 +271,9 @@ async function _renderContent(uriPath) {
 
   /* eslint-disable no-restricted-syntax */
   for (const [token, args] of Object.entries(tree)) {
-    const recordId = pathSection === args.name ? pathRecordId : null;
+    const recordId = pathSection === args.name && args.params.multiple !== 'true'
+      ? pathRecordId
+      : null;
     /* eslint-disable-next-line no-await-in-loop */
     let recordContent = await Section.contentFor(args, recordId);
 


### PR DESCRIPTION
**Problem**
On a details page (e.g., a template that renders an individual section entry), there is currently no way to display _all_ of the records from the same section. For example, you can't show a blog post detail and also list the most recent 5 blog posts on the same page.

**Solution**
Allow `multiple=true` to forcefully query for the most recent 5 blog posts.

Resolves #34