### PR TITLE
Filter out sections that don't have fields

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -475,18 +475,24 @@ async function findRecord(ctx, next) {
 
 async function _getContentSections() {
   return Section.scope('content').findAll({
-    where: {
-      fields: {
-        [Sequelize.Op.ne]: {},
-      },
-    },
+    /*
+     * BUG: Postgresql can't compare equality in where clause,
+     * so for now we'll just filter the sections after SQL
+     *
+     * https://github.com/vapid/vapid/issues/149
+     */
+    // where: {
+    //   fields: {
+    //     [Sequelize.Op.ne]: {},
+    //   },
+    // },
     order: [
       [Sequelize.literal(`CASE WHEN name = '${Section.DEFAULT_NAME}' THEN 1 ELSE 0 END`), 'DESC'],
       ['multiple', 'ASC'],
       [Sequelize.cast(Sequelize.json('options.priority'), 'integer'), 'ASC'],
       ['name', 'ASC'],
     ],
-  });
+  }).then(sections => Utils.filter(sections, section => !Utils.isEmpty(section.fields)));
 }
 
 async function _newRecordAction(ctx, errors = {}) {


### PR DESCRIPTION
PostgreSQL was failing when looking for empty JSON objects in a where clause. This fix uses an array filter after the SQL executes.

Resolves #149