### PR TITLE
Use priority when ordering a section index page

### DIFF
--- a/lib/Database/models/section.js
+++ b/lib/Database/models/section.js
@@ -132,7 +132,7 @@ module.exports = (sequelize, DataTypes) => {
             ...value,
             _name: key,
           }], [])
-          .sort((a, b) => (parseInt(a.priority, 10) < parseInt(b.priority, 10) ? -1 : 1));
+          .sort((a, b) => a.priority - b.priority || isNaN(a.priority) - isNaN(b.priority));
       },
     },
 

--- a/lib/Database/models/section.js
+++ b/lib/Database/models/section.js
@@ -100,7 +100,7 @@ module.exports = (sequelize, DataTypes) => {
        * @return {array} first three fields
        */
       tableColumns: function tableColumns() {
-        return Object.keys(this.fields).slice(0, 3);
+        return this.sortedFields.slice(0, 3).map(f => f._name);
       },
 
       /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vapid/cli",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "license": "MIT",
   "description": "A template-driven content management system",
   "repository": "vapid/vapid",


### PR DESCRIPTION
Previously, while it was possible to set the order of form fields via the `priority` attribute, the section index did not take priority into account while creating table columns.

* The section index table now sorts columns according to `priority`
* The sorting function now places undefined priorities at the end

Resolves #144 