### PR TITLE
Bug fix: previewing non-required field

### DIFF
--- a/lib/Database/models/record.js
+++ b/lib/Database/models/record.js
@@ -219,7 +219,7 @@ module.exports = (sequelize, DataTypes) => {
   Record.prototype.previewContent = function previewContent(fieldName, section) {
     const directive = directives.find(section.fields[fieldName]);
     const rendered = directive.preview(this.content[fieldName]);
-    return rendered.length > 140 ? `${rendered.slice(0, 140)}...` : rendered;
+    return rendered && rendered.length > 140 ? `${rendered.slice(0, 140)}...` : rendered;
   };
 
   /*


### PR DESCRIPTION
Resolves #167

Previewing any empty, non-required image would fail with a 500 error.