### PR TITLE
feat: Template XML and JSON Files

### DIFF
--- a/lib/Database/Builder.js
+++ b/lib/Database/Builder.js
@@ -81,7 +81,7 @@ class Builder {
   /* eslint-disable no-restricted-syntax */
   get tree() {
     const tree = {};
-    const templates = glob.sync(resolve(this.dir, '**/*.html'));
+    const templates = glob.sync(resolve(this.dir, '**/*.{html,xml,json}'));
 
     for (const tpl of templates) {
       const parsed = TemplateCompiler.fromFile(tpl).parse();

--- a/lib/Database/Builder.js
+++ b/lib/Database/Builder.js
@@ -81,7 +81,7 @@ class Builder {
   /* eslint-disable no-restricted-syntax */
   get tree() {
     const tree = {};
-    const templates = glob.sync(resolve(this.dir, '**/*.{html,xml,json}'));
+    const templates = glob.sync(resolve(this.dir, '**/*.{html,xml,rss,json}'));
 
     for (const tpl of templates) {
       const parsed = TemplateCompiler.fromFile(tpl).parse();

--- a/lib/Renderer/index.js
+++ b/lib/Renderer/index.js
@@ -15,14 +15,15 @@ const { views: viewsPath } = Paths.getDashboardPaths();
  * Renders content into site template
  *
  * @param {string} uriPath
+ * @param {string} extension
  * @return {string} rendered HTML
  *
  * @todo Use Promise.all when fetching content
  */
-exports.renderContent = async function renderContent(uriPath) {
+exports.renderContent = async function renderContent(uriPath, extension) {
   const content = {};
   const { Section } = this.db.models;
-  const pathAnalyzer = new services.UriPathAnalyzer(uriPath, this.paths.www);
+  const pathAnalyzer = new services.UriPathAnalyzer(uriPath, extension, this.paths.www);
   const [file, pathSection, pathRecordId] = pathAnalyzer.perform();
 
   if (!file) {

--- a/lib/runners/VapidBuilder/index.js
+++ b/lib/runners/VapidBuilder/index.js
@@ -99,7 +99,7 @@ class VapidBuilder extends Vapid {
 
     // Fetch all potential template files. These are validated below before compilation.
     Logger.info('Compiling All Templates');
-    const templates = await glob(path.join(this.paths.www, '**/*.{html,xml,json}'));
+    const templates = await glob(path.join(this.paths.www, '**/*.{html,xml,rss,json}'));
 
     // For every `.html`, `.xml`, and `.json` template discovered in `/www`...
     /* eslint-disable no-await-in-loop */

--- a/lib/runners/VapidBuilder/index.js
+++ b/lib/runners/VapidBuilder/index.js
@@ -99,9 +99,9 @@ class VapidBuilder extends Vapid {
 
     // Fetch all potential template files. These are validated below before compilation.
     Logger.info('Compiling All Templates');
-    const templates = await glob(path.join(this.paths.www, '**/*.html'));
+    const templates = await glob(path.join(this.paths.www, '**/*.{html,xml,json}'));
 
-    // For every `.html` template discovered in `/www`...
+    // For every `.html`, `.xml`, and `.json` template discovered in `/www`...
     /* eslint-disable no-await-in-loop */
     for (const tmpl of templates) {
       const parsed = path.parse(path.relative(this.paths.www, tmpl));
@@ -120,10 +120,11 @@ class VapidBuilder extends Vapid {
           Logger.extra([`Created: ${record.permalink}.html`]);
         }
 
-      // If this isn't a partial, it must be a page. Render it!
+      // If this isn't a partial, it must be a page, an XML or a JSON file. Render it!
       } else {
+        const ext = path.extname(tmpl);
         const name = parsed.name === 'index' && parsed.dir ? parsed.dir : parsed.name;
-        await this.renderUrl(`/${name}`, path.join(dest, `${name}.html`));
+        await this.renderUrl(`/${name}`, path.join(dest, `${name}${ext}`), ext);
         Logger.extra([`Created: /${name}`]);
       }
     }
@@ -136,8 +137,8 @@ class VapidBuilder extends Vapid {
     return stats;
   }
 
-  async renderUrl(url, out) {
-    const body = await renderContent.call(this, url);
+  async renderUrl(url, out, ext) {
+    const body = await renderContent.call(this, url, ext);
     mkdirp.sync(path.dirname(out));
     await fs.writeFileSync(out, body);
   }

--- a/lib/runners/VapidServer/index.js
+++ b/lib/runners/VapidServer/index.js
@@ -80,6 +80,9 @@ class VapidServer extends Vapid {
       const ext = path.extname(ctx.path);
 
       switch (ext) {
+        case '':
+          ctx.type = 'text/html';
+          break;
         case '.html':
           ctx.type = 'text/html';
           break;
@@ -101,8 +104,9 @@ class VapidServer extends Vapid {
       if (this.config.cache && !cacheValue) {
         cache.set(cacheKey, ctx.body);
       }
-
-      if (this.liveReload) { _injectLiveReload(ctx, this.config.port); }
+      
+      // Only inject liveReload into HTML files if it is enabled
+      if (this.liveReload && ctx.type == 'text/html') { _injectLiveReload(ctx, this.config.port); }
     });
   }
 

--- a/lib/runners/VapidServer/index.js
+++ b/lib/runners/VapidServer/index.js
@@ -104,9 +104,9 @@ class VapidServer extends Vapid {
       if (this.config.cache && !cacheValue) {
         cache.set(cacheKey, ctx.body);
       }
-      
+
       // Only inject liveReload into HTML files if it is enabled
-      if (this.liveReload && ctx.type == 'text/html') { _injectLiveReload(ctx, this.config.port); }
+      if (this.liveReload && ctx.type === 'text/html') { _injectLiveReload(ctx, this.config.port); }
     });
   }
 

--- a/lib/runners/VapidServer/index.js
+++ b/lib/runners/VapidServer/index.js
@@ -1,4 +1,5 @@
 const http = require('http');
+const path = require('path');
 
 const Koa = require('koa');
 
@@ -73,6 +74,27 @@ class VapidServer extends Vapid {
     app.use(async (ctx) => {
       const cacheKey = ctx.path;
       const cacheValue = this.config.cache && cache.get(cacheKey);
+
+      // Get file name extension from path to set content type accordingly
+      // TODO: Make this not hardcoded
+      const ext = path.extname(ctx.path);
+
+      switch (ext) {
+        case '.html':
+          ctx.type = 'text/html';
+          break;
+        case '.xml':
+          ctx.type = 'application/xml';
+          break;
+        case '.rss':
+          ctx.type = 'application/rss+xml';
+          break;
+        case '.json':
+          ctx.type = 'application/json';
+          break;
+        default:
+          break;
+      }
 
       ctx.body = cacheValue || await renderContent.call(this, ctx.path);
 

--- a/lib/services/uri_path_analyzer.js
+++ b/lib/services/uri_path_analyzer.js
@@ -4,10 +4,12 @@ const { join, resolve } = require('path');
 class UriPathAnalyzer {
   /**
    * @param {string} path - request path
+   * @param {string} extension - file name extension
    * @param {string} templateDir - local directory, where template files reside
    */
-  constructor(path, templateDir) {
+  constructor(path, extension, templateDir) {
     this.path = path;
+    this.extension = extension;
     this.templateDir = templateDir;
   }
 
@@ -35,10 +37,10 @@ class UriPathAnalyzer {
         file = sysPath;
       }
     } else {
-      const htmlPath = `${sysPath.replace(/\/$/, '')}.html`;
+      const filePath = `${sysPath.replace(/\/$/, '')}${this.extension}`;
 
-      if (fs.existsSync(htmlPath)) {
-        file = htmlPath;
+      if (fs.existsSync(filePath)) {
+        file = filePath;
       } else {
         [sectionName, recordSlug = ''] = this.path.slice(1).split('/');
         recordId = recordSlug.split('-').pop();

--- a/lib/utils/paths.js
+++ b/lib/utils/paths.js
@@ -3,6 +3,8 @@ const Boom = require('@hapi/boom');
 const mkdirp = require('mkdirp');
 
 const HTML_FILE_EXTS = { '': 1, '.html': 1 };
+const XML_FILE_EXTS = { '': 1, '.xml': 1 };
+const JSON_FILE_EXTS = { '': 1, '.json': 1 };
 const SASS_FILE_EXTS = { '.scss': 1, '.sass': 1 };
 
 /**
@@ -65,7 +67,7 @@ exports.isTemplatePartial = function isTemplatePartial(filePath) {
 };
 
 /**
- * Validates that a given path is a valid asset path. HTML and s[c|a]ss files are excluded.
+ * Validates that a given path is a valid asset path. HTML, XML, JSON and s[c|a]ss files are excluded.
  * TODO: Its weird that this will return a string for the human readable error. Fix it.
  *
  * @param {string} path
@@ -74,7 +76,7 @@ exports.isTemplatePartial = function isTemplatePartial(filePath) {
 exports.isAssetPath = function isAssetPath(filePath) {
   const ext = path.extname(filePath);
 
-  if (HTML_FILE_EXTS[ext] || filePath.match(/.pack\.[js|scss|sass]/)) {
+  if (HTML_FILE_EXTS[ext] || XML_FILE_EXTS[ext] || JSON_FILE_EXTS[ext] || filePath.match(/.pack\.[js|scss|sass]/)) {
     return false;
   } else if (SASS_FILE_EXTS[ext]) {
     const suggestion = filePath.replace(/\.(scss|sass)$/, '.css');

--- a/lib/utils/paths.js
+++ b/lib/utils/paths.js
@@ -3,7 +3,7 @@ const Boom = require('@hapi/boom');
 const mkdirp = require('mkdirp');
 
 const HTML_FILE_EXTS = { '': 1, '.html': 1 };
-const XML_FILE_EXTS = { '': 1, '.xml': 1 };
+const XML_FILE_EXTS = { '.xml': 1, '.rss': 1 };
 const JSON_FILE_EXTS = { '': 1, '.json': 1 };
 const SASS_FILE_EXTS = { '.scss': 1, '.sass': 1 };
 

--- a/lib/utils/paths.js
+++ b/lib/utils/paths.js
@@ -67,7 +67,8 @@ exports.isTemplatePartial = function isTemplatePartial(filePath) {
 };
 
 /**
- * Validates that a given path is a valid asset path. HTML, XML, JSON and s[c|a]ss files are excluded.
+ * Validates that a given path is a valid asset path.
+ * HTML, XML, JSON and s[c|a]ss files are excluded.
  * TODO: Its weird that this will return a string for the human readable error. Fix it.
  *
  * @param {string} path


### PR DESCRIPTION
XML and JSON files can now include template tags and will be compiled. This allows for dynamically generated RSS/JSON feeds and XML Sitemaps.

For now, the template compiler processes files with an `.xml`, `.rss` or `.json` extension the same way it processes HTML files. This works fine as long as you do not use content types that output HTML.

This functionality can be improved by modifying the template compiler to recognize XML and JSON files and output some content types differently (e. g. render the Image content type without the `img` tag by default, so one does not have to use the `tag=false` parameter).

I have tested it locally with an XML and a JSON file. Should I add a proper test? The changes are not huge though.