### PR TITLE
fix: Make WebSocket Connection Secure

### DIFF
--- a/assets/dashboard/javascripts/dashboard/websocket.js
+++ b/assets/dashboard/javascripts/dashboard/websocket.js
@@ -1,7 +1,7 @@
 const liveReload = document.querySelector('meta[name=livereload]');
 
 if ('WebSocket' in window && liveReload) {
-  const ws = new WebSocket(`ws://${location.host}/livereload`);
+  const ws = new WebSocket(`ws${location.protocol == 'https:' ? 's' : ''}://${location.host}/livereload`);
 
   document.addEventListener("turbolinks:load", () => {
     const $build = $('.build.button');


### PR DESCRIPTION
I found the issue for #174 (WYSIWYG Editor not working in Chrome and Firefox): When using HTTPS, the dashboard tries to make an insecure WebSocket connection using the `ws:` protocol. This works in Safari somehow, but Google Chrome/Microsoft Edge and Mozilla Firefox don’t like that. I have fixed it so the dashboard will use a secure connection using the `wss:` protocol when the website is HTTPS.