### PR TITLE
fix: Fix #unless being ignored on production server

### DIFF
--- a/lib/TemplateCompiler/goatee.js
+++ b/lib/TemplateCompiler/goatee.js
@@ -561,7 +561,8 @@
   // TODO: The conditionMet regex is meant to bypass placeholders--need a better way to handle these
   Writer.prototype.renderConditional = function renderConditional(conditional, name, token, context, partials, originalTemplate) {
     const value = context.search(name);
-    let conditionMet = !Utils.isEmpty(value) && Utils.isFunction(value.match) && !value.match(/{{[\w:]+}}/);
+
+    let conditionMet = !Utils.isEmpty(value) && !String(value).match(/{{[\w:]+}}/);
 
     if (conditional == 'unless') {
       conditionMet = !conditionMet;


### PR DESCRIPTION
This fixes a bug where `#unless` is being ignored on a production server. It works in the production environment, but in the development environment, the contents of the `#unless` block will always be rendered, even if the section is not empty.

Changes:

- explicitly turn `value` into a string to prevent error where `value.match` is not a function
- remove missing function `Utils.isFunction()`