### PR TITLE
fix: avoid loading hidden files as middleware

### DIFF
--- a/lib/runners/VapidServer/index.js
+++ b/lib/runners/VapidServer/index.js
@@ -77,11 +77,12 @@ class VapidServer extends Vapid {
 
       // Get file name extension from path to set content type accordingly
       // TODO: Make this not hardcoded
-      const ext = path.extname(ctx.path);
+      let ext = path.extname(ctx.path);
 
       switch (ext) {
         case '':
           ctx.type = 'text/html';
+          ext = '.html';
           break;
         case '.html':
           ctx.type = 'text/html';
@@ -99,7 +100,7 @@ class VapidServer extends Vapid {
           break;
       }
 
-      ctx.body = cacheValue || await renderContent.call(this, ctx.path);
+      ctx.body = cacheValue || await renderContent.call(this, ctx.path, ext);
 
       if (this.config.cache && !cacheValue) {
         cache.set(cacheKey, ctx.body);

--- a/lib/runners/VapidServer/middleware/imageProcessing.js
+++ b/lib/runners/VapidServer/middleware/imageProcessing.js
@@ -5,7 +5,8 @@ const {
   statSync,
   writeFile,
 } = require('fs');
-const { extname, join } = require('path');
+const mkdirp = require('mkdirp');
+const { extname, join, dirname } = require('path');
 
 const sharp = require('sharp');
 
@@ -41,6 +42,9 @@ module.exports = function imageProcessing(paths) {
     const cacheKey = crypto.createHash('md5')
       .update(`${ctx.url}${fileStats.mtime}`)
       .digest('hex');
+
+
+
     const cachePath = join(paths.cache, `${cacheKey}${ext}`);
     const cacheExists = existsSync(cachePath);
 
@@ -51,6 +55,9 @@ module.exports = function imageProcessing(paths) {
       if (cacheExists) {
         return readFileSync(cachePath);
       }
+
+      // make sure cache directory exists
+      mkdirp.sync(dirname(cachePath));
 
       const buffer = await sharp(filePath)
         .rotate()

--- a/lib/runners/VapidServer/middleware/imageProcessing.js
+++ b/lib/runners/VapidServer/middleware/imageProcessing.js
@@ -43,8 +43,6 @@ module.exports = function imageProcessing(paths) {
       .update(`${ctx.url}${fileStats.mtime}`)
       .digest('hex');
 
-
-
     const cachePath = join(paths.cache, `${cacheKey}${ext}`);
     const cacheExists = existsSync(cachePath);
 

--- a/lib/runners/VapidServer/middleware/index.js
+++ b/lib/runners/VapidServer/middleware/index.js
@@ -4,6 +4,7 @@ const { Utils } = require('../../../utils');
 
 fs.readdirSync(__dirname).forEach((file) => {
   if (file === 'index.js') return;
+  if (file.startsWith('.')) return;
 
   const name = Utils.camelCase(basename(file, '.js'));
   /* eslint-disable-next-line global-require, import/no-dynamic-require */


### PR DESCRIPTION
When editing files in the middleware directory with vim, exception is raised after loading a swap file. 