### PR TITLE
fix: image cache not functioning if cache folder was not yet created

### DIFF
--- a/lib/runners/VapidServer/middleware/imageProcessing.js
+++ b/lib/runners/VapidServer/middleware/imageProcessing.js
@@ -5,12 +5,12 @@ const {
   statSync,
   writeFile,
 } = require('fs');
-const { extname, join } = require('path');
+const mkdirp = require('mkdirp');
+const { extname, join, dirname } = require('path');
 
 const sharp = require('sharp');
 
 const { Utils } = require('../../../utils');
-
 const ACCEPTED_FORMATS = {
   '.jpg': 1,
   '.jpeg': 1,
@@ -51,6 +51,9 @@ module.exports = function imageProcessing(paths) {
       if (cacheExists) {
         return readFileSync(cachePath);
       }
+
+      // make sure cache directory exists
+      mkdirp.sync(dirname(cachePath));
 
       const buffer = await sharp(filePath)
         .rotate()


### PR DESCRIPTION
Image processing middleware expects a folder named `cache` inside `data` folder of the vapid site, if missing `writeFile(cachePath, buffer, Utils.noop);` will fail without any error or exception. 

I Propose to fix this by creating the directory if missing when needed.