### PR TITLE
fix: image resize cache missing cache directory

### DIFF
--- a/lib/runners/VapidServer/middleware/imageProcessing.js
+++ b/lib/runners/VapidServer/middleware/imageProcessing.js
@@ -5,7 +5,8 @@ const {
   statSync,
   writeFile,
 } = require('fs');
-const { extname, join } = require('path');
+const mkdirp = require('mkdirp');
+const { extname, join, dirname } = require('path');
 
 const sharp = require('sharp');
 
@@ -51,6 +52,9 @@ module.exports = function imageProcessing(paths) {
       if (cacheExists) {
         return readFileSync(cachePath);
       }
+
+      // make sure cache directory exists
+      mkdirp.sync(dirname(cachePath));
 
       const buffer = await sharp(filePath)
         .rotate()

--- a/lib/runners/VapidServer/middleware/index.js
+++ b/lib/runners/VapidServer/middleware/index.js
@@ -4,6 +4,7 @@ const { Utils } = require('../../../utils');
 
 fs.readdirSync(__dirname).forEach((file) => {
   if (file === 'index.js') return;
+  if (file.startsWith('.')) return;
 
   const name = Utils.camelCase(basename(file, '.js'));
   /* eslint-disable-next-line global-require, import/no-dynamic-require */


### PR DESCRIPTION
Image processing middleware expects a folder named cache inside data folder of the vapid site, if missing writeFile(cachePath, buffer, Utils.noop); will fail without any error or exception. Also fixed middleware automatically loading vim swp files as middleware. 

I made a new pull request because I noticed the previous ones were messy and did not pass circleci