### PR TITLE
fix: show file name along with template not found error

### DIFF
--- a/lib/Renderer/index.js
+++ b/lib/Renderer/index.js
@@ -27,7 +27,7 @@ exports.renderContent = async function renderContent(uriPath, extension) {
   const [file, pathSection, pathRecordId] = pathAnalyzer.perform();
 
   if (!file) {
-    throw Boom.notFound('Template not found');
+    throw Boom.notFound(`Template not found: ${uriPath}${extension}`);
   }
 
   const partials = glob.sync(resolve(this.paths.www, '**/_*.html'));


### PR DESCRIPTION
I was stuck on the build step due to a "Template not found" error arising out of a stray ```flaticon.html``` file inside the ```/fonts``` folder of a web template I was working with. 

The error was not very helpful since it wasn't telling me which template was not found.
I have added the name of the file to the error now for easier debugging.